### PR TITLE
adds archival note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This repository is superseded by the work at ToIP Technical Stack Working Group ACDC Task Force
+
+https://github.com/trustoverip/tswg-acdc-specification
+
 # Authentic Chained Data Containers (ACDC)
 
 This is the working area for the individual Internet-Draft, "Authentic Chained Data Containers (ACDC)".


### PR DESCRIPTION
Due to the proposed move to the Trust over IP Foundation, we should archive this repository.